### PR TITLE
[*64] Allow more fastTailCalls involving structs

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8186,13 +8186,15 @@ public:
         bool compPublishStubParam : 1; // EAX captured in prolog will be available through an instrinsic
         bool compRetBuffDefStack : 1;  // The ret buff argument definitely points into the stack.
 
-        var_types compRetType;       // Return type of the method as declared in IL
-        var_types compRetNativeType; // Normalized return type as per target arch ABI
-        unsigned  compILargsCount;   // Number of arguments (incl. implicit but not hidden)
-        unsigned  compArgsCount;     // Number of arguments (incl. implicit and     hidden)
-        unsigned  compRetBuffArg;    // position of hidden return param var (0, 1) (BAD_VAR_NUM means not present);
-        int compTypeCtxtArg; // position of hidden param for type context for generic code (CORINFO_CALLCONV_PARAMTYPE)
-        unsigned       compThisArg; // position of implicit this pointer param (not to be confused with lvaArg0Var)
+        var_types compRetType;          // Return type of the method as declared in IL
+        var_types compRetNativeType;    // Normalized return type as per target arch ABI
+        unsigned  compILargsCount;      // Number of arguments (incl. implicit but not hidden)
+        unsigned  compArgsCount;        // Number of arguments (incl. implicit and     hidden)
+        unsigned  compArgRegCount;      // Number of integer locals
+        unsigned  compOtherArgRegCount; // Number of multireg args
+        unsigned  compRetBuffArg;       // position of hidden return param var (0, 1) (BAD_VAR_NUM means not present);
+        int compTypeCtxtArg;            // position of hidden param for type context for generic code (CORINFO_CALLCONV_PARAMTYPE)
+        unsigned       compThisArg;     // position of implicit this pointer param (not to be confused with lvaArg0Var)
         unsigned       compILlocalsCount; // Number of vars : args + locals (incl. implicit but not hidden)
         unsigned       compLocalsCount;   // Number of vars : args + locals (incl. implicit and     hidden)
         unsigned       compMaxStack;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -239,9 +239,11 @@ void Compiler::lvaInitTypeRef()
     // Finally the local variables
     //-------------------------------------------------------------------------
 
-    unsigned                varNum    = varDscInfo.varNum;
-    LclVarDsc*              varDsc    = varDscInfo.varDsc;
-    CORINFO_ARG_LIST_HANDLE localsSig = info.compMethodInfo->locals.args;
+    unsigned                argRegNum       = varDscInfo.intRegArgNum;
+    unsigned                otherArgRegNum  = varDscInfo.floatRegArgNum;
+    unsigned                varNum          = varDscInfo.varNum;
+    LclVarDsc*              varDsc          = varDscInfo.varDsc;
+    CORINFO_ARG_LIST_HANDLE localsSig       = info.compMethodInfo->locals.args;
 
     for (unsigned i = 0; i < info.compMethodInfo->locals.numArgs;
          i++, varNum++, varDsc++, localsSig = info.compCompHnd->getArgNext(localsSig))
@@ -261,6 +263,9 @@ void Compiler::lvaInitTypeRef()
             lvaSetClass(varNum, clsHnd);
         }
     }
+
+    info.compArgRegCount = argRegNum;
+    info.compOtherArgRegCount = otherArgRegNum;
 
     if ( // If there already exist unsafe buffers, don't mark more structs as unsafe
         // as that will cause them to be placed along with the real unsafe buffers,

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1714,7 +1714,6 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
         fgArgTabEntryPtr argTabEntry = comp->gtArgEntryByNode(call, putArgStkNode);
         assert(argTabEntry);
         unsigned callerArgNum = argTabEntry->argNum - calleeNonStandardArgCount;
-        noway_assert(callerArgNum < comp->info.compArgsCount);
 
         unsigned   callerArgLclNum = callerArgNum;
         LclVarDsc* callerArgDsc    = comp->lvaTable + callerArgLclNum;

--- a/tests/src/JIT/opt/FastTailCall/DoNotFastTailCallWithStructs.cs
+++ b/tests/src/JIT/opt/FastTailCall/DoNotFastTailCallWithStructs.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+// 10 byte struct
+public struct A
+{
+    public int a;
+    public int b;
+    public short c;
+}
+
+// 32 byte struct
+public struct B
+{
+    public long a;
+    public long b;
+    public long c;
+    public long d;
+}
+
+public class DoNotFastTailCallWithStructs
+{
+    static A a;
+    static B b;
+
+    public static void Foo(B b, int count=1000)
+    {
+        if (count == 100)
+        {
+            return count;
+        }
+
+        if (count-- % 2 == 0)
+        {
+            return Foo(a, count);
+        }
+
+        else
+        {
+            return Foo(b, count);
+        }
+    }
+
+    public static void Foo(A a, int count=1000)
+    {
+        if (count == 100)
+        {
+            return count;
+        }
+
+        if (count-- % 2 == 0)
+        {
+            return Foo(a, count);
+        }
+
+        else
+        {
+            return Foo(b, count);
+        }
+    }
+
+    public static int Main()
+    {
+        a = new A();
+        b = new B();
+
+        a.a = 100;
+        a.b = 1000;
+        a.c = 10000;
+
+        b.a = 500;
+        b.b = 5000;
+        b.c = 50000;
+        b.d = 500000;
+
+        return Foo(a);
+    }
+}

--- a/tests/src/JIT/opt/FastTailCall/DoNotFastTailCallWithStructs.csproj
+++ b/tests/src/JIT/opt/FastTailCall/DoNotFastTailCallWithStructs.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DoNotFastTailCallWithStructs.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/FastTailCall/StackFixup.cs
+++ b/tests/src/JIT/opt/FastTailCall/StackFixup.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct A

--- a/tests/src/JIT/opt/FastTailCall/StackFixup.csproj
+++ b/tests/src/JIT/opt/FastTailCall/StackFixup.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="StackFixup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/FastTailCall/StructPassingSimple.cs
+++ b/tests/src/JIT/opt/FastTailCall/StructPassingSimple.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+// 10 byte struct
+public struct A
+{
+    public int a;
+    public int b;
+    public short c;
+}
+
+class TailCallStructPassingSimple
+{
+    // Simple tail call candidate that would be ignored on Arm64 and amd64 Unix
+    // due to https://github.com/dotnet/coreclr/issues/2666
+    public static int ImplicitTailCallTenByteStruct(A a, int count=1000)
+    {
+        if (count-- == 0)
+        {
+            return 100;
+        }
+
+        return ImplicitTailCallTenByteStruct(a, count);
+    }
+
+    public static int Main()
+    {
+        A temp = new A();
+        temp.a = 50;
+        temp.b = 500;
+        temp.c = 62;
+
+        int ret = ImplicitTailCallTenByteStruct(temp);
+        return ret;
+    } 
+}

--- a/tests/src/JIT/opt/FastTailCall/StructPassingSimple.csproj
+++ b/tests/src/JIT/opt/FastTailCall/StructPassingSimple.csproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -22,19 +21,8 @@
       <Visible>False</Visible>
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
-    <DebugType>None</DebugType>
-    <NoLogo>True</NoLogo>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
-    <Optimize>True</Optimize>
-    <JitOptimizationSensitive>True</JitOptimizationSensitive>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
-    <Compile Include="FastTailCallStackFixup.cs" />
+    <Compile Include="StructPassingSimple.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
Before this change structs on Arm64 and Amd64 Unix could
pessimize when we could fastTailCall if they were engregisterable
and took more than one register.

This updates the canFastTailCall function to allow this pattern
to be fastTailCalled.