### PR TITLE
Build xunit wrappers on unix

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -346,7 +346,7 @@ build_Tests_internal()
         __msbuildErr="\"/flp2:ErrorsOnly;LogFile=${__BuildErr}\""
 
         # Generate build command
-        buildCommand="$__ProjectRoot/run.sh build -Project=$projectName -MsBuildLog=${__msbuildLog} -MsBuildWrn=${__msbuildWrn} -MsBuildErr=${__msbuildErr} -MsBuildEventLogging=\"/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log\" $extraBuildParameters $__RunArgs $__UnprocessedBuildArgs"
+        buildCommand="$__ProjectRoot/run.sh build -Project=$projectName -MsBuildLog=${__msbuildLog} -MsBuildWrn=${__msbuildWrn} -MsBuildErr=${__msbuildErr} $extraBuildParameters $__RunArgs $__UnprocessedBuildArgs"
 
         echo "Building step '$stepName' via $buildCommand"
 
@@ -727,7 +727,7 @@ __CrossgenExe="$__CrossComponentBinDir/crossgen"
 
 isMSBuildOnNETCoreSupported
 
-# CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to set.
+# CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to it.
 # This is needed by CLI to function.
 if [ -z "$HOME" ]; then
     if [ ! -d "$__ProjectDir/temp_home" ]; then

--- a/config.json
+++ b/config.json
@@ -76,7 +76,7 @@
       "description": "MsBuild logging options.",
       "valueType": "passThrough",
       "values": [],
-      "defaultValue": "/l:BinClashLogger,Tools/net46/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log"
+      "defaultValue": ""
     },
     "FilterToOSGroup": {
       "description": "Specifies the OSGroup.",

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -79,8 +79,10 @@ $(_XunitEpilog)
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <TargetFrameworkIdentifier Condition ="('$(BuildTestsAgainstPackages)' != 'true') And ('$(BuildOS)' == 'Windows_NT')">.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier Condition ="('$(BuildTestsAgainstPackages)' != 'true') And ('$(BuildOS)' != 'Windows_NT')">.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion Condition ="('$(BuildTestsAgainstPackages)' != 'true') And ('$(BuildOS)' == 'Windows_NT')">v4.5</TargetFrameworkVersion>
-    <TargetFramework Condition="'$(BuildOS)' != 'Windows_NT'">netcoreapp2.0</TargetFramework>
+    <TargetFrameworkVersion Condition ="('$(BuildTestsAgainstPackages)' != 'true') And ('$(BuildOS)' != 'Windows_NT')">v2.2</TargetFrameworkVersion>
+    <TargetFramework Condition="'$(BuildOS)' != 'Windows_NT'">netcoreapp2.2</TargetFramework>
     <NugetTargetMonikerShort Condition ="('$(BuildTestsAgainstPackages)' != 'true') And ('$(BuildOS)' == 'Windows_NT')">net45</NugetTargetMonikerShort>
     <IsXunitWrapperProject>true</IsXunitWrapperProject>
     <SkipSigning>true</SkipSigning>

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -128,7 +128,7 @@ def call_msbuild(coreclr_repo_location,
     common_msbuild_arguments = ["/nologo", "/nodeReuse:false", "/p:Platform=%s" % arch]
 
     if sequential:
-        common_msbuild_arguments += ["/p:ParrallelRun=false"]
+        common_msbuild_arguments += ["/p:ParallelRun=false"]
     else:
         common_msbuild_arguments += ["/maxcpucount"]
 

--- a/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
+++ b/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
@@ -1,10 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyName>CoreclrTestWrapperLib</AssemblyName>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>

--- a/tests/src/TestWrappersConfig/TestWrappersConfig.csproj
+++ b/tests/src/TestWrappersConfig/TestWrappersConfig.csproj
@@ -13,19 +13,26 @@
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>$(XunitPackageVersion)</Version>
+      <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.assert">
+      <ExcludeAssets>All</ExcludeAssets>
       <Version>$(XunitPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit.core">
       <Version>$(XunitPackageVersion)</Version>
+      <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.msbuild">
       <Version>$(XunitPackageVersion)</Version>
+      <ExcludeAssets>All</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>


### PR DESCRIPTION
The generated wrapper needs to target netcoreapp on unix. I had to
exclude assets from the xunit package and introduce a dependency on
the private corefx bits, to resolve a dependency conflict in which the
generated wrapper was depending on an older System.Runtime.dll than
the helper library.

I also disabled binclash logging, because the wrapper build binplaces
the helper library to the same location multiple times. I couldn't
find a simple way to disable binclash logging for the wrapper build
only, since that requires passing an empty switch to run.exe, and bash
word splitting makes this nontrivial from build-test.