### PR TITLE
Correctly generate TestEnv xplat

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -238,7 +238,7 @@ build_Tests()
 
     echo "Starting the Managed Tests Build..."
 
-    #build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
+    build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
 
     if [ $? -ne 0 ]; then
         echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"


### PR DESCRIPTION
Note that this will still require changes to the test wrapper
to actually source the TestEnv on unix